### PR TITLE
Add Laravel 11+12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+.idea

--- a/src/Auth/NoDatabaseUserProvider.php
+++ b/src/Auth/NoDatabaseUserProvider.php
@@ -72,4 +72,12 @@ class NoDatabaseUserProvider extends UserProvider
 
         return false;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rehashPasswordIfRequired(Authenticatable $user, #[\SensitiveParameter] array $credentials, bool $force = false)
+    {
+        // We can't rehash LDAP users passwords.
+    }
 }


### PR DESCRIPTION
Implementation for `rehashPasswordIfRequired` method copied from `Adldap2-Laravel`'s follow up package `LdapRecord-Laravel`
https://github.com/DirectoryTree/LdapRecord-Laravel/blob/d2f56341c18ab603978fa8432496bf9825eef7ec/src/Auth/NoDatabaseUserProvider.php#L61